### PR TITLE
Prevent dragging when user is clicking the button

### DIFF
--- a/src/Row.js
+++ b/src/Row.js
@@ -29,7 +29,11 @@ const Row = ({ id, text, handleDrag, handleDrop }) => {
       onDragStart={handleDrag}
       onDrop={handleDrop}
     >
-      <span className="dragIcon" />
+      <span 
+        className="dragIcon"
+        draggable="true" 
+        onDragStart={(ev) => ev.preventDefault()} 
+      />
       <span>{text}</span>
     </StyledRow>
   );


### PR DESCRIPTION
Now it is possible to prevent dragging list items when clicking on the button. May require adding _event.stopPropagation()_ in the future. Code modifications according to this SO post:

[https://stackoverflow.com/questions/44048685/prevent-child-element-from-being-dragged-when-parent-is-draggable/44049369](https://stackoverflow.com/questions/44048685/prevent-child-element-from-being-dragged-when-parent-is-draggable/44049369)